### PR TITLE
Remove explicit empty destructors

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v2
 
@@ -29,6 +29,7 @@ jobs:
 
       - name: Run reuse lint
         run: reuse lint
+        if: matrix.python-version == '3.10'
 
       - name: Run pytest
         run: pytest --nomatlab

--- a/vqf/cpp/basicvqf.cpp
+++ b/vqf/cpp/basicvqf.cpp
@@ -42,11 +42,6 @@ BasicVQF::BasicVQF(const BasicVQFParams &params, vqf_real_t gyrTs, vqf_real_t ac
     setup();
 }
 
-BasicVQF::~BasicVQF()
-{
-
-}
-
 void BasicVQF::updateGyr(const vqf_real_t gyr[3])
 {
     // gyroscope prediction step

--- a/vqf/cpp/basicvqf.hpp
+++ b/vqf/cpp/basicvqf.hpp
@@ -233,7 +233,6 @@ public:
      * @param magTs sampling time of the magnetometer measurements in seconds (the value of `gyrTs` is used if set to -1)
      */
     BasicVQF(const BasicVQFParams& params, vqf_real_t gyrTs, vqf_real_t accTs=-1.0, vqf_real_t magTs=-1.0);
-    ~BasicVQF();
 
     /**
      * @brief Performs gyroscope update step.

--- a/vqf/cpp/vqf.cpp
+++ b/vqf/cpp/vqf.cpp
@@ -71,11 +71,6 @@ VQF::VQF(const VQFParams &params, vqf_real_t gyrTs, vqf_real_t accTs, vqf_real_t
     setup();
 }
 
-VQF::~VQF()
-{
-
-}
-
 void VQF::updateGyr(const vqf_real_t gyr[3])
 {
     // rest detection

--- a/vqf/cpp/vqf.hpp
+++ b/vqf/cpp/vqf.hpp
@@ -662,7 +662,6 @@ public:
      * @param magTs sampling time of the magnetometer measurements in seconds (the value of `gyrTs` is used if set to -1)
      */
     VQF(const VQFParams& params, vqf_real_t gyrTs, vqf_real_t accTs=-1.0, vqf_real_t magTs=-1.0);
-    ~VQF();
 
     /**
      * @brief Performs gyroscope update step.


### PR DESCRIPTION
Fixes #4

Alternatively, we could set the destructor explicitly to the default destructor:
```c++
~VQF() = default;
```
but that requires c++11 and the build system is currently configured to build it as c++98.