### PR TITLE
Make gyro bias clip relative to any previously known bias.

### DIFF
--- a/vqf/cpp/vqf.cpp
+++ b/vqf/cpp/vqf.cpp
@@ -82,8 +82,8 @@ void VQF::updateGyr(const vqf_real_t gyr[3])
 
         vqf_real_t biasClip = params.biasClip*vqf_real_t(M_PI/180.0);
         if (state.restLastSquaredDeviations[0] >= square(params.restThGyr*vqf_real_t(M_PI/180.0))
-                || fabs(state.restLastGyrLp[0]) > biasClip || fabs(state.restLastGyrLp[1]) > biasClip
-                || fabs(state.restLastGyrLp[2]) > biasClip) {
+                || fabs(state.restLastGyrLp[0] - state.bias[0]) > biasClip || fabs(state.restLastGyrLp[1] - state.bias[1]) > biasClip
+                || fabs(state.restLastGyrLp[2] - state.bias[2]) > biasClip) {
             state.restT = 0.0;
             state.restDetected = false;
         }

--- a/vqf/matlab/VQF.m
+++ b/vqf/matlab/VQF.m
@@ -234,7 +234,7 @@ classdef VQF < handle
                 squaredDeviation = dot(deviation, deviation);
 
                 biasClip = obj.params.biasClip*pi/180;
-                if squaredDeviation >= (obj.params.restThGyr*pi/180.0)^2 || max(abs(gyrLp)) > biasClip
+                if squaredDeviation >= (obj.params.restThGyr*pi/180.0)^2 || max(abs(gyrLp - obj.state.bias)) > biasClip
                     obj.state.restT = 0.0;
                     obj.state.restDetected = false;
                 end

--- a/vqf/pyvqf.py
+++ b/vqf/pyvqf.py
@@ -217,7 +217,7 @@ class PyVQF:
             squaredDeviation = deviation.dot(deviation)
 
             biasClip = self._params.biasClip*np.pi/180.0
-            if squaredDeviation >= (self._params.restThGyr*np.pi/180.0)**2 or np.max(np.abs(gyrLp)) > biasClip:
+            if squaredDeviation >= (self._params.restThGyr*np.pi/180.0)**2 or np.max(np.abs(gyrLp - self._state.bias)) > biasClip:
                 self._state.restT = 0.0
                 self._state.restDetected = False
             self._state.restLastGyrLp = gyrLp

--- a/vqf/pyvqf.py
+++ b/vqf/pyvqf.py
@@ -217,7 +217,10 @@ class PyVQF:
             squaredDeviation = deviation.dot(deviation)
 
             biasClip = self._params.biasClip*np.pi/180.0
-            if squaredDeviation >= (self._params.restThGyr*np.pi/180.0)**2 or np.max(np.abs(gyrLp - self._state.bias)) > biasClip:
+            if (
+                squaredDeviation >= (self._params.restThGyr*np.pi/180.0)**2 or
+                np.max(np.abs(gyrLp - self._state.bias)) > biasClip
+            ):
                 self._state.restT = 0.0
                 self._state.restDetected = False
             self._state.restLastGyrLp = gyrLp


### PR DESCRIPTION
Just ran into this: for some reason the native calibration tool for my sensor is doing a poor job of calibrating the gyro bias (or the sensor isn't taking the bias into account when producing quaternions?), so the default gyroClip value was causing the algorithm to never detect a rest. Setting the gyro bias via `VQF::setBiasEstimate` didn't help, which led me to the realization that the gyroClip doesn't take into account any known bias.

It personally makes more sense to me to make gyroClip relative to any already known bias than it does to raise gyroClip in this situation. Maybe there's a reason not to do this, though.

(aside: i don't have a good environment to test the python or matlab implementations right now, so you should probably make sure they still interpret/compile before accepting this PR.)