### PR TITLE
Fix out-of-bounds write in restLastSquaredDeviations fill

### DIFF
--- a/vqf/cpp/vqf.cpp
+++ b/vqf/cpp/vqf.cpp
@@ -552,7 +552,7 @@ void VQF::setRestBiasEstEnabled(bool enabled)
     }
     params.restBiasEstEnabled = enabled;
     state.restDetected = false;
-    std::fill(state.restLastSquaredDeviations, state.restLastSquaredDeviations + 3, 0.0);
+    std::fill(state.restLastSquaredDeviations, state.restLastSquaredDeviations + 2, 0.0);
     state.restT = 0.0;
     std::fill(state.restLastGyrLp, state.restLastGyrLp + 3, 0.0);
     std::fill(state.restGyrLpState, state.restGyrLpState + 3*2, NaN);
@@ -669,7 +669,7 @@ void VQF::resetState()
     std::fill(state.motionBiasEstBiasLpState, state.motionBiasEstBiasLpState + 2*2, NaN);
 #endif
 
-    std::fill(state.restLastSquaredDeviations, state.restLastSquaredDeviations + 3, 0.0);
+    std::fill(state.restLastSquaredDeviations, state.restLastSquaredDeviations + 2, 0.0);
     state.restT = 0.0;
     std::fill(state.restLastGyrLp, state.restLastGyrLp + 3, 0.0);
     std::fill(state.restGyrLpState, state.restGyrLpState + 3*2, NaN);


### PR DESCRIPTION
## Summary

`VQFState::restLastSquaredDeviations` is declared as `vqf_real_t[2]` ([vqf.hpp L390](https://github.com/dlaidig/vqf/blob/main/vqf/cpp/vqf.hpp#L390)), but `std::fill` uses `+ 3` as the end iterator in two places, writing **one element past the array boundary**:

- [`resetState()`](https://github.com/dlaidig/vqf/blob/main/vqf/cpp/vqf.cpp#L672) (vqf.cpp L672)
- [`setRestBiasEstEnabled()`](https://github.com/dlaidig/vqf/blob/main/vqf/cpp/vqf.cpp#L555) (vqf.cpp L555)

```cpp
// Before (undefined behavior — writes 3 elements into a size-2 array)
std::fill(state.restLastSquaredDeviations, state.restLastSquaredDeviations + 3, 0.0);

// After (correct — matches the declared array size of 2)
std::fill(state.restLastSquaredDeviations, state.restLastSquaredDeviations + 2, 0.0);
```

## Why this hasn't caused visible issues

Due to the `VQFState` struct layout, the out-of-bounds write lands on the immediately following `restT` member, which is then unconditionally assigned `0.0` on the very next line in both call sites. So the overflow value (`0.0`) is silently overwritten, masking the bug at runtime.

However, this is still **undefined behavior** per the C++ standard. Compilers are free to assume UB does not occur, so this could break under different optimization levels, compiler versions, or struct packing/alignment changes.

## Changes

- `vqf.cpp` L555 (`setRestBiasEstEnabled`): `+ 3` → `+ 2`
- `vqf.cpp` L672 (`resetState`): `+ 3` → `+ 2`